### PR TITLE
add spec for LoginJSONController. add refactor for JSONControllers

### DIFF
--- a/app/features-json/json_controller.rb
+++ b/app/features-json/json_controller.rb
@@ -1,0 +1,36 @@
+require "sinatra/json"
+
+module FastlaneCI
+  ##
+  # JSONController mixin allows `params` method to return the params from the parsed request body
+  #
+  module JSONController
+    def self.included(mod)
+      mod.before do
+        if request.content_type != "application/json"
+          logger.warn("JSON Controller expected json requests, but got `#{request.content_type}`")
+        end
+      end
+    end
+
+    def params
+      return @json_params if defined?(@json_params)
+
+      request.body.rewind
+      body = request.body.read
+      unless body.empty?
+        @json_params = JSON.parse(body)
+        # make the accessor indifferent to strings or procs
+        @json_params.default_proc = proc do |hash, key|
+          if hash.key?(key.to_s)
+            hash[key.to_s]
+          end
+        end
+
+        @json_params.merge!(super)
+
+        return @json_params
+      end
+    end
+  end
+end

--- a/app/features-json/login_json_controller.rb
+++ b/app/features-json/login_json_controller.rb
@@ -1,6 +1,7 @@
 require_relative "../shared/controller_base"
 require_relative "../services/user_service"
 require_relative "../services/dot_keys_variable_service"
+require_relative "json_controller"
 
 require "jwt"
 require "json"
@@ -8,15 +9,13 @@ require "json"
 module FastlaneCI
   # Controller responsible of handling the login process using JWT token.
   class LoginJSONController < ControllerBase
+    include JSONController
+
     HOME = "/login"
 
-    post HOME.to_s do
-      # Allow this endpoint to be requested with { Content-Type: application/json }
-      payload = params
-      payload = JSON.parse(request.body.read).symbolize_keys unless params[:path]
-      email = payload[:email]
-      password = payload[:password]
-      user = Services.user_service.login(email: email, password: password)
+    post HOME do
+      # Allow this endpoint to be requested with { Content-Type: application/json }
+      user = Services.user_service.login(email: params[:email], password: params[:password])
       if user.nil?
         halt(401)
       else
@@ -39,7 +38,7 @@ module FastlaneCI
         iss: "fastlane.ci",
         # We are only going to pass the user primary key to the client in order
         # to make sure that the calls being made to other services are made with
-        # the correct relationship tree between objects being checked.
+        # the correct relationship tree between objects being checked.
         user: user.id.to_s
       }
     end

--- a/spec/features-json/login_json_controller_spec.rb
+++ b/spec/features-json/login_json_controller_spec.rb
@@ -1,18 +1,24 @@
 require "spec_helper"
 require "app/features-json/login_json_controller"
+require "app/services/onboarding_service"
+require "app/services/user_service"
 
 describe FastlaneCI::LoginJSONController do
+  def app
+    described_class
+  end
+  let(:user) { double("User", id: "some-id") }
+  let(:json) { JSON.parse(last_response.body) }
 
-  def app() described_class end
+  before do
+    allow(FastlaneCI::Services.onboarding_service).to receive(:correct_setup?).and_return(true)
+    allow(FastlaneCI::Services.user_service).to receive(:login).and_return(user)
+    allow(FastlaneCI.dot_keys).to receive(:encryption_key).and_return("test")
+  end
 
   it "should return a valid JWT token using the global encryption key" do
-    
-    post "/login", { username: "fastlane", password: "password" }.to_json, { "CONTENT_TYPE" => "application/json" }
-    
-    # TODO: For whatever reason I can't figure out, the response is not what
-    # I'm expecting here, so tests are failing.
+    post "/login", { email: "fastlane", password: "password" }.to_json, { "CONTENT_TYPE" => "application/json" }
     expect(last_response).to be_ok
-    expect(last_response).to be_json
-
+    expect(json).to have_key("token")
   end
 end


### PR DESCRIPTION
this PR adds specs to #765.

Also, it introduces a new `JSONController` mixin that encapsulates some of the json parsing thats done over and over.

In this particular case, it solved for `Hash#symbolize_keys` being undefined.